### PR TITLE
Added primitive check to data types and changed all import syntax

### DIFF
--- a/api.mustache
+++ b/api.mustache
@@ -30,7 +30,7 @@ export class {{classname}} {
      * {{notes}}
      {{#allParams}}* @param {{paramName}} {{description}}
      {{/allParams}}*/
-    public {{nickname}} ({{#allParams}}{{paramName}}{{^required}}?{{/required}}: lib.{{{dataType}}}, {{/allParams}}extraHttpRequestParams?: any ) : Observable<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}{}{{/returnType}}> {
+    public {{nickname}} ({{#allParams}}{{paramName}}{{^required}}?{{/required}}: lib.{{{dataType}}}, {{/allParams}}extraHttpRequestParams?: any ) : Observable<lib.{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}{}{{/returnType}}> {
         const path = this.basePath + '{{path}}'{{#pathParams}}
             .replace('{' + '{{baseName}}' + '}', String({{paramName}})){{/pathParams}};
 

--- a/api.mustache
+++ b/api.mustache
@@ -1,7 +1,7 @@
 import {Http, Headers, RequestOptionsArgs, Response} from 'angular2/http';
 import {Injectable} from 'angular2/core';
 import {Observable} from 'rxjs/Observable';
-import * from 'api.d';
+import * as lib from  './api.d';
 
 /* tslint:disable:no-unused-variable member-ordering */
 
@@ -30,7 +30,7 @@ export class {{classname}} {
      * {{notes}}
      {{#allParams}}* @param {{paramName}} {{description}}
      {{/allParams}}*/
-    public {{nickname}} ({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}extraHttpRequestParams?: any ) : Observable<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}{}{{/returnType}}> {
+    public {{nickname}} ({{#allParams}}{{paramName}}{{^required}}?{{/required}}: lib.{{{dataType}}}, {{/allParams}}extraHttpRequestParams?: any ) : Observable<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}{}{{/returnType}}> {
         const path = this.basePath + '{{path}}'{{#pathParams}}
             .replace('{' + '{{baseName}}' + '}', String({{paramName}})){{/pathParams}};
 

--- a/model.mustache
+++ b/model.mustache
@@ -1,3 +1,5 @@
+import * as lib from  './api.d';
+
 'use strict';
 
 {{#models}}
@@ -7,7 +9,7 @@
  * {{{description}}}
  */
 {{/description}}
-export interface {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{
+export interface {{classname}} {{#parent}}extends lib.{{{parent}}} {{/parent}}{
 {{#vars}}
 
 {{#description}}
@@ -15,7 +17,7 @@ export interface {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{
      * {{{description}}}
      */
 {{/description}}
-    {{name}}: {{#isEnum}}{{classname}}.{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{datatype}}}{{/isEnum}};
+    {{name}}: {{^isPrimitiveType}}lib.{{/isPrimitiveType}}{{#isEnum}}{{classname}}.{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{datatype}}}{{/isEnum}};
 {{/vars}}
 }
 


### PR DESCRIPTION
Please check and confirm if this works.
By the way, if the type is an Array. Ex: myVar: Array<myDTO> it still adds lib. in front of Array. I will look more into it later.